### PR TITLE
Registry sort - I hope I can help - Create a cleaner Log 

### DIFF
--- a/src/main/java/net/minecraftforge/fml/common/toposort/ModSortingException.java
+++ b/src/main/java/net/minecraftforge/fml/common/toposort/ModSortingException.java
@@ -37,7 +37,7 @@ public class ModSortingException extends EnhancedRuntimeException implements IDi
     {
         public SortingExceptionData(T node, Set<T> visitedNodes)
         {
-            this.firstBadNode = node;
+            this.firstBadNode = node; 
             this.visitedNodes = visitedNodes;
         }
 

--- a/src/main/java/net/minecraftforge/fml/common/toposort/ModSortingException.java
+++ b/src/main/java/net/minecraftforge/fml/common/toposort/ModSortingException.java
@@ -33,7 +33,7 @@ public class ModSortingException extends EnhancedRuntimeException implements IDi
 {
     private static final long serialVersionUID = 1L;
 
-    public class SortingExceptionData<T>
+    public static class SortingExceptionData<T>
     {
         public SortingExceptionData(T node, Set<T> visitedNodes)
         {

--- a/src/main/java/net/minecraftforge/fml/common/toposort/ModSortingException.java
+++ b/src/main/java/net/minecraftforge/fml/common/toposort/ModSortingException.java
@@ -37,7 +37,7 @@ public class ModSortingException extends EnhancedRuntimeException implements IDi
     {
         public SortingExceptionData(T node, Set<T> visitedNodes)
         {
-            this.firstBadNode = node; 
+            this.firstBadNode = node;
             this.visitedNodes = visitedNodes;
         }
 

--- a/src/main/java/net/minecraftforge/registries/RegistrySortingException.java
+++ b/src/main/java/net/minecraftforge/registries/RegistrySortingException.java
@@ -17,42 +17,75 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-package net.minecraftforge.registries;
+package net.minecraftforge.fml.common.toposort;
 
+import java.util.Set;
+
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraftforge.fml.client.GuiSortingProblem;
+import net.minecraftforge.fml.client.IDisplayableError;
 import net.minecraftforge.fml.common.EnhancedRuntimeException;
-import net.minecraftforge.fml.common.toposort.ModSortingException;
-import net.minecraftforge.fml.common.toposort.ModSortingException.SortingExceptionData;
+import net.minecraftforge.fml.common.ModContainer;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 
-import java.util.Arrays;
-
-public class RegistrySortingException extends EnhancedRuntimeException
+public class ModSortingException extends EnhancedRuntimeException implements IDisplayableError
 {
-	private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
 
-	private SortingExceptionData<?> sortingExceptionData;
+    public class SortingExceptionData<T>
+    {
+        public SortingExceptionData(T node, Set<T> visitedNodes)
+        {
+            this.firstBadNode = node;
+            this.visitedNodes = visitedNodes;
+        }
 
-	public <T> RegistrySortingException(ModSortingException e)
-	{
-		super(e.getMessage());
-		sortingExceptionData =e.getExceptionData();
-	}
+        private T firstBadNode;
+        private Set<T> visitedNodes;
 
-	@SuppressWarnings("unchecked")
-	public <T> SortingExceptionData<T> getExceptionData()
-	{
-		return (SortingExceptionData<T>) sortingExceptionData;
-	}
+        public T getFirstBadNode()
+        {
+            return firstBadNode;
+        }
+        public Set<T> getVisitedNodes()
+        {
+            return visitedNodes;
+        }
+    }
 
-	@Override
-	protected void printStackTrace(WrappedPrintStream stream)
-	{
-		SortingExceptionData<GameData.RegistryHolder> exceptionData = getExceptionData();
-		stream.println("A dependency cycle was detected in the registry set so an ordering cannot be determined");
-		stream.println("The first registry in the cycle is " + exceptionData.getFirstBadNode());
-		stream.println("The registry cycle involves:");
-		for (GameData.RegistryHolder mc : exceptionData.getVisitedNodes())
-		{
-			stream.println(String.format("\t%s : before: %s, after: %s", mc.toString(), Arrays.toString(mc.getDependants()), Arrays.toString(mc.getDependencies())));
-		}
-	}
+    private SortingExceptionData<?> sortingExceptionData;
+
+    public <T> ModSortingException(String string, T node, Set<T> visitedNodes)
+    {
+        super(string);
+        this.sortingExceptionData = new SortingExceptionData<T>(node, visitedNodes);
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> SortingExceptionData<T> getExceptionData()
+    {
+        return (SortingExceptionData<T>) sortingExceptionData;
+    }
+
+    @Override
+    protected void printStackTrace(WrappedPrintStream stream)
+    {
+        SortingExceptionData<ModContainer> exceptionData = getExceptionData();
+        stream.println("A dependency cycle was detected in the input mod set so an ordering cannot be determined");
+        stream.println("The first mod in the cycle is " + exceptionData.getFirstBadNode());
+        stream.println("The mod cycle involves:");
+        for (ModContainer mc : exceptionData.getVisitedNodes())
+        {
+            stream.println(String.format("\t%s : before: %s, after: %s", mc.toString(), mc.getDependants(), mc.getDependencies()));
+        }
+    }
+
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public GuiScreen createGui()
+    {
+        return new GuiSortingProblem(this);
+    }
 }

--- a/src/main/java/net/minecraftforge/registries/RegistrySortingException.java
+++ b/src/main/java/net/minecraftforge/registries/RegistrySortingException.java
@@ -19,6 +19,7 @@
 
 package net.minecraftforge.registries;
 
+import com.google.common.collect.Sets.SetView;
 import net.minecraftforge.fml.common.EnhancedRuntimeException;
 import net.minecraftforge.fml.common.toposort.ModSortingException;
 import net.minecraftforge.fml.common.toposort.ModSortingException.SortingExceptionData;
@@ -31,10 +32,20 @@ public class RegistrySortingException extends EnhancedRuntimeException
 
 	private SortingExceptionData<?> sortingExceptionData;
 
-	public <T> RegistrySortingException(ModSortingException e)
+	public RegistrySortingException(ModSortingException e)
 	{
-		super(e.getMessage());
-		sortingExceptionData =e.getExceptionData();
+		this(e.getMessage(),e.getExceptionData());
+	}
+
+	public <T> RegistrySortingException(String message, SortingExceptionData<T> sortingExceptionData)
+	{
+		super(message);
+		this.sortingExceptionData = sortingExceptionData;
+	}
+
+	public <T> RegistrySortingException(String message, T node, SetView<T> setView)
+	{
+		this(message,new SortingExceptionData<>(node,setView));
 	}
 
 	@SuppressWarnings("unchecked")

--- a/src/main/java/net/minecraftforge/registries/RegistrySortingException.java
+++ b/src/main/java/net/minecraftforge/registries/RegistrySortingException.java
@@ -17,75 +17,42 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-package net.minecraftforge.fml.common.toposort;
+package net.minecraftforge.registries;
 
-import java.util.Set;
-
-import net.minecraft.client.gui.GuiScreen;
-import net.minecraftforge.fml.client.GuiSortingProblem;
-import net.minecraftforge.fml.client.IDisplayableError;
 import net.minecraftforge.fml.common.EnhancedRuntimeException;
-import net.minecraftforge.fml.common.ModContainer;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
+import net.minecraftforge.fml.common.toposort.ModSortingException;
+import net.minecraftforge.fml.common.toposort.ModSortingException.SortingExceptionData;
 
-public class ModSortingException extends EnhancedRuntimeException implements IDisplayableError
+import java.util.Arrays;
+
+public class RegistrySortingException extends EnhancedRuntimeException
 {
-    private static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = 1L;
 
-    public class SortingExceptionData<T>
-    {
-        public SortingExceptionData(T node, Set<T> visitedNodes)
-        {
-            this.firstBadNode = node;
-            this.visitedNodes = visitedNodes;
-        }
+	private SortingExceptionData<?> sortingExceptionData;
 
-        private T firstBadNode;
-        private Set<T> visitedNodes;
+	public <T> RegistrySortingException(ModSortingException e)
+	{
+		super(e.getMessage());
+		sortingExceptionData =e.getExceptionData();
+	}
 
-        public T getFirstBadNode()
-        {
-            return firstBadNode;
-        }
-        public Set<T> getVisitedNodes()
-        {
-            return visitedNodes;
-        }
-    }
+	@SuppressWarnings("unchecked")
+	public <T> SortingExceptionData<T> getExceptionData()
+	{
+		return (SortingExceptionData<T>) sortingExceptionData;
+	}
 
-    private SortingExceptionData<?> sortingExceptionData;
-
-    public <T> ModSortingException(String string, T node, Set<T> visitedNodes)
-    {
-        super(string);
-        this.sortingExceptionData = new SortingExceptionData<T>(node, visitedNodes);
-    }
-
-    @SuppressWarnings("unchecked")
-    public <T> SortingExceptionData<T> getExceptionData()
-    {
-        return (SortingExceptionData<T>) sortingExceptionData;
-    }
-
-    @Override
-    protected void printStackTrace(WrappedPrintStream stream)
-    {
-        SortingExceptionData<ModContainer> exceptionData = getExceptionData();
-        stream.println("A dependency cycle was detected in the input mod set so an ordering cannot be determined");
-        stream.println("The first mod in the cycle is " + exceptionData.getFirstBadNode());
-        stream.println("The mod cycle involves:");
-        for (ModContainer mc : exceptionData.getVisitedNodes())
-        {
-            stream.println(String.format("\t%s : before: %s, after: %s", mc.toString(), mc.getDependants(), mc.getDependencies()));
-        }
-    }
-
-
-    @Override
-    @SideOnly(Side.CLIENT)
-    public GuiScreen createGui()
-    {
-        return new GuiSortingProblem(this);
-    }
+	@Override
+	protected void printStackTrace(WrappedPrintStream stream)
+	{
+		SortingExceptionData<GameData.RegistryHolder> exceptionData = getExceptionData();
+		stream.println("A dependency cycle was detected in the registry set so an ordering cannot be determined");
+		stream.println("The first registry in the cycle is " + exceptionData.getFirstBadNode());
+		stream.println("The registry cycle involves:");
+		for (GameData.RegistryHolder mc : exceptionData.getVisitedNodes())
+		{
+			stream.println(String.format("\t%s : before: %s, after: %s", mc.toString(), Arrays.toString(mc.getDependants()), Arrays.toString(mc.getDependencies())));
+		}
+	}
 }

--- a/src/main/java/net/minecraftforge/registries/RegistrySortingException.java
+++ b/src/main/java/net/minecraftforge/registries/RegistrySortingException.java
@@ -34,7 +34,7 @@ public class RegistrySortingException extends EnhancedRuntimeException
 	public <T> RegistrySortingException(ModSortingException e)
 	{
 		super(e.getMessage());
-		sortingExceptionData = e.getExceptionData();
+		sortingExceptionData =e.getExceptionData();
 	}
 
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
This prevents the topological sort Method from printing out "Mod sorting failed." though it actually sorted Registries, by adding an additional Callback which performs the logging. In addition to that it enables you not having to throw and instantly catch the ModSortingException which is created by the topologicalSort Method and instead throw your own Registry Sorting Exception.

I hope I do nothing wrong with this pull request... I just spend this afternoon implementing something similiar and then noticed, that you have been doing that already and I therefore hope, that I can help you to get this future PR into forge as fast and clean as possible.

:)

(I just copied that from the one which went into the wrong branch...)